### PR TITLE
Add prayer-time sync and wear complication

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ tilesToolingPreview = "1.4.0"
 horologistComposeTools = "0.6.17"
 horologistTiles = "0.6.17"
 watchfaceComplicationsDataSourceKtx = "1.2.1"
+coroutines = "1.8.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -53,6 +54,8 @@ androidx-tiles-tooling-preview = { group = "androidx.wear.tiles", name = "tiles-
 horologist-compose-tools = { group = "com.google.android.horologist", name = "horologist-compose-tools", version.ref = "horologistComposeTools" }
 horologist-tiles = { group = "com.google.android.horologist", name = "horologist-tiles", version.ref = "horologistTiles" }
 androidx-watchface-complications-data-source-ktx = { group = "androidx.wear.watchface", name = "watchface-complications-data-source-ktx", version.ref = "watchfaceComplicationsDataSourceKtx" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.coroutines.play.services)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
@@ -5,6 +5,12 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -15,6 +21,14 @@ class MainActivity : AppCompatActivity() {
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
+        }
+
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            CoroutineScope(Dispatchers.Main).launch {
+                PrayerTimesSync.update(this@MainActivity)
+            }
+        } else {
+            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION), 0)
         }
     }
 }

--- a/mobile/src/main/java/com/noxob/namazvakti/PrayerTimesSync.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/PrayerTimesSync.kt
@@ -1,0 +1,35 @@
+package com.noxob.namazvakti
+
+import android.content.Context
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.URL
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+object PrayerTimesSync {
+    suspend fun update(context: Context) {
+        val locationClient = LocationServices.getFusedLocationProviderClient(context)
+        val location = locationClient.lastLocation.await() ?: return
+        val date = LocalDate.now()
+        val offsetMin = ZoneOffset.systemDefault().rules.getOffset(date.atStartOfDay()).totalSeconds / 60
+        val url = "https://vakit.vercel.app/api/timesForGPS?lat=${'$'}{location.latitude}&lng=${'$'}{location.longitude}&date=${'$'}date&days=1&timezoneOffset=${'$'}offsetMin&calculationMethod=Turkey&lang=tr"
+        val json = withContext(Dispatchers.IO) {
+            URL(url).openStream().bufferedReader().use { it.readText() }
+        }
+        val timesArray = JSONObject(json).getJSONObject("times").getJSONArray(date.toString())
+        val times = ArrayList<String>()
+        for (i in 0 until timesArray.length()) {
+            times.add(timesArray.getString(i))
+        }
+        val request = PutDataMapRequest.create("/prayer_times").apply {
+            dataMap.putStringArrayList("times", times)
+        }.asPutDataRequest().setUrgent()
+        Wearable.getDataClient(context).putDataItem(request).await()
+    }
+}

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     implementation(libs.horologist.compose.tools)
     implementation(libs.horologist.tiles)
     implementation(libs.androidx.watchface.complications.data.source.ktx)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.coroutines.play.services)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)

--- a/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
@@ -6,31 +6,33 @@ import androidx.wear.watchface.complications.data.PlainComplicationText
 import androidx.wear.watchface.complications.data.ShortTextComplicationData
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
-import java.util.Calendar
+import com.noxob.namazvakti.data.PrayerTimesRepository
+import java.time.Duration
+import java.time.LocalTime
 
-/**
- * Skeleton for complication data source that returns short text.
- */
 class MainComplicationService : SuspendingComplicationDataSourceService() {
 
     override fun getPreviewData(type: ComplicationType): ComplicationData? {
         if (type != ComplicationType.SHORT_TEXT) {
             return null
         }
-        return createComplicationData("Mon", "Monday")
+        return createComplicationData("60m", "Next prayer in 60 minutes")
     }
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData {
-        return when (Calendar.getInstance().get(Calendar.DAY_OF_WEEK)) {
-            Calendar.SUNDAY -> createComplicationData("Sun", "Sunday")
-            Calendar.MONDAY -> createComplicationData("Mon", "Monday")
-            Calendar.TUESDAY -> createComplicationData("Tue", "Tuesday")
-            Calendar.WEDNESDAY -> createComplicationData("Wed", "Wednesday")
-            Calendar.THURSDAY -> createComplicationData("Thu", "Thursday")
-            Calendar.FRIDAY -> createComplicationData("Fri!", "Friday!")
-            Calendar.SATURDAY -> createComplicationData("Sat", "Saturday")
-            else -> throw IllegalArgumentException("too many days")
-        }
+        val times = PrayerTimesRepository(this).getPrayerTimes()
+        val now = LocalTime.now()
+        val next = times?.firstOrNull { it.isAfter(now) }
+        val duration = next?.let { Duration.between(now, it) }
+        val text = duration?.let { formatDuration(it) } ?: "--"
+        val desc = duration?.let { "Next prayer in ${formatDuration(it)}" } ?: "No data"
+        return createComplicationData(text, desc)
+    }
+
+    private fun formatDuration(duration: Duration): String {
+        val hours = duration.toHours()
+        val minutes = duration.toMinutes() % 60
+        return if (hours > 0) "${'$'}hours h ${'$'}minutes m" else "${'$'}minutes m"
     }
 
     private fun createComplicationData(text: String, contentDescription: String) =

--- a/wear/src/main/java/com/noxob/namazvakti/data/PrayerTimesRepository.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/data/PrayerTimesRepository.kt
@@ -1,0 +1,18 @@
+package com.noxob.namazvakti.data
+
+import android.content.Context
+import android.net.Uri
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.tasks.await
+import java.time.LocalTime
+
+class PrayerTimesRepository(private val context: Context) {
+    suspend fun getPrayerTimes(): List<LocalTime>? {
+        val uri = Uri.parse("wear://*/prayer_times")
+        val item = Wearable.getDataClient(context).getDataItem(uri).await() ?: return null
+        val dataMap = DataMapItem.fromDataItem(item).dataMap
+        val times = dataMap.getStringArrayList("times") ?: return null
+        return times.map { LocalTime.parse(it) }
+    }
+}


### PR DESCRIPTION
## Summary
- fetch daily prayer times from vakit.vercel.app using phone location and push to watch via data layer
- display remaining time to next prayer in wear OS complication
- add coroutine, location and network permissions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b48264d8833380ca6936d8c503b6