### PR TITLE
Show prayer times on mobile and add settings

### DIFF
--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.adhan2)
+    implementation(libs.kotlinx.datetime)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NamazVakti">
+        <activity android:name=".SettingsActivity" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/mobile/src/main/java/com/noxob/namazvakti/LocationSender.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/LocationSender.kt
@@ -11,7 +11,7 @@ import com.google.android.gms.location.Priority
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 
-class LocationSender(private val context: Context) {
+class LocationSender(private val context: Context, private val onLocation: ((Location) -> Unit)? = null) {
 
     private val fusedClient = LocationServices.getFusedLocationProviderClient(context)
     private val dataClient = Wearable.getDataClient(context)
@@ -40,6 +40,7 @@ class LocationSender(private val context: Context) {
     }
 
     private fun send(location: Location) {
+        onLocation?.invoke(location)
         Log.d("LocationSender", "Sending location ${'$'}{location.latitude}, ${'$'}{location.longitude}")
         val request = PutDataMapRequest.create("/location").apply {
             dataMap.putDouble("lat", location.latitude)

--- a/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.noxob.namazvakti
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
@@ -9,10 +10,33 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.TextView
+import com.batoulapps.adhan2.CalculationMethod
+import com.batoulapps.adhan2.Coordinates
+import com.batoulapps.adhan2.Madhab
+import com.batoulapps.adhan2.PrayerTimes
+import com.batoulapps.adhan2.data.DateComponents
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.TimeZone
+import kotlinx.datetime.toJavaInstant
 
 class MainActivity : AppCompatActivity() {
 
-    private val locationSender by lazy { LocationSender(this) }
+    private val locationSender by lazy { LocationSender(this) { location ->
+        displayPrayerTimes(location.latitude, location.longitude)
+    } }
+
+    private lateinit var fajrView: TextView
+    private lateinit var sunriseView: TextView
+    private lateinit var dhuhrView: TextView
+    private lateinit var asrView: TextView
+    private lateinit var maghribView: TextView
+    private lateinit var ishaView: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +47,13 @@ class MainActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+        fajrView = findViewById(R.id.fajr_time)
+        sunriseView = findViewById(R.id.sunrise_time)
+        dhuhrView = findViewById(R.id.dhuhr_time)
+        asrView = findViewById(R.id.asr_time)
+        maghribView = findViewById(R.id.maghrib_time)
+        ishaView = findViewById(R.id.isha_time)
+
         if (hasLocationPermission()) {
             Log.d("MainActivity", "Location permission already granted")
             locationSender.sendLastLocation()
@@ -54,5 +85,51 @@ class MainActivity : AppCompatActivity() {
         } else {
             Log.d("MainActivity", "Location permission denied")
         }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
+            R.id.action_settings -> {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+
+    private fun displayPrayerTimes(lat: Double, lng: Double) {
+        val times = computeTimes(lat, lng)
+        val views = listOf(fajrView, sunriseView, dhuhrView, asrView, maghribView, ishaView)
+        val names = listOf("Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha")
+        val formatter = DateTimeFormatter.ofPattern("HH:mm")
+        for (i in views.indices) {
+            views[i].text = "${names[i]}: ${times[i].format(formatter)}"
+        }
+    }
+
+    private fun computeTimes(lat: Double, lng: Double): List<LocalTime> {
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        val methodName = prefs.getString("method", CalculationMethod.TURKEY.name)!!
+        val madhabName = prefs.getString("madhab", Madhab.SHAFI.name)!!
+        val method = CalculationMethod.valueOf(methodName)
+        val params = method.parameters.copy(madhab = Madhab.valueOf(madhabName))
+        val date = LocalDate.now()
+        val coordinates = Coordinates(lat, lng)
+        val components = DateComponents(date.year, date.monthValue, date.dayOfMonth)
+        val times = PrayerTimes(coordinates, components, params)
+        val offsetMinutes = TimeZone.getDefault().rawOffset / 60000
+        val zoneOffset = ZoneOffset.ofTotalSeconds(offsetMinutes * 60)
+        return listOf(
+            times.fajr,
+            times.sunrise,
+            times.dhuhr,
+            times.asr,
+            times.maghrib,
+            times.isha
+        ).map { it.toJavaInstant().atOffset(zoneOffset).toLocalTime() }
     }
 }

--- a/mobile/src/main/java/com/noxob/namazvakti/SettingsActivity.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/SettingsActivity.kt
@@ -1,0 +1,51 @@
+package com.noxob.namazvakti
+
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Spinner
+import androidx.appcompat.app.AppCompatActivity
+import com.batoulapps.adhan2.CalculationMethod
+import com.batoulapps.adhan2.Madhab
+
+class SettingsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings)
+
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+
+        val methodSpinner = findViewById<Spinner>(R.id.method_spinner)
+        val methods = CalculationMethod.values()
+        methodSpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            methods.map { it.name }
+        ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
+        val currentMethod = prefs.getString("method", CalculationMethod.TURKEY.name)
+        methodSpinner.setSelection(methods.indexOfFirst { it.name == currentMethod })
+        methodSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                prefs.edit().putString("method", methods[position].name).apply()
+            }
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+
+        val madhabSpinner = findViewById<Spinner>(R.id.madhab_spinner)
+        val madhabs = Madhab.values()
+        madhabSpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            madhabs.map { it.name }
+        ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
+        val currentMadhab = prefs.getString("madhab", Madhab.SHAFI.name)
+        madhabSpinner.setSelection(madhabs.indexOfFirst { it.name == currentMadhab })
+        madhabSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                prefs.edit().putString("madhab", madhabs[position].name).apply()
+            }
+            override fun onNothingSelected(parent: AdapterView<*>) {}
+        }
+    }
+}

--- a/mobile/src/main/res/layout/activity_main.xml
+++ b/mobile/src/main/res/layout/activity_main.xml
@@ -7,13 +7,52 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
+    <LinearLayout
+        android:id="@+id/prayer_times_container"
+        android:orientation="vertical"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/fajr_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Fajr: --" />
+
+        <TextView
+            android:id="@+id/sunrise_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sunrise: --" />
+
+        <TextView
+            android:id="@+id/dhuhr_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Dhuhr: --" />
+
+        <TextView
+            android:id="@+id/asr_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Asr: --" />
+
+        <TextView
+            android:id="@+id/maghrib_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Maghrib: --" />
+
+        <TextView
+            android:id="@+id/isha_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Isha: --" />
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/src/main/res/layout/activity_settings.xml
+++ b/mobile/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Spinner
+        android:id="@+id/method_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Spinner
+        android:id="@+id/madhab_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>

--- a/mobile/src/main/res/menu/main_menu.xml
+++ b/mobile/src/main/res/menu/main_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_settings"
+        android:title="@string/settings"
+        app:showAsAction="never" />
+</menu>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">NamazVakti</string>
+    <string name="settings">Settings</string>
 </resources>


### PR DESCRIPTION
## Summary
- display daily prayer times on mobile using the Adhan2 library
- allow location callbacks to compute times and send to wear
- add settings screen for calculation method and madhab

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9151f6a08333a01e7f6574596f9a