### PR TITLE
Display complication prayer times on Wear tile

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -26,6 +26,13 @@
         <activity
             android:name=".SettingsActivity"
             android:exported="false" />
+        <service
+            android:name=".SettingsRequestService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.BIND_LISTENER" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/mobile/src/main/java/com/noxob/namazvakti/LocationSender.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/LocationSender.kt
@@ -39,6 +39,14 @@ class LocationSender(private val context: Context) {
         }
     }
 
+    fun sendCityName(city: String) {
+        val request = PutDataMapRequest.create("/city").apply {
+            dataMap.putString("name", city)
+            dataMap.putLong("time", System.currentTimeMillis())
+        }.asPutDataRequest().setUrgent()
+        dataClient.putDataItem(request)
+    }
+
     private fun send(location: Location) {
         Log.d("LocationSender", "Sending location ${'$'}{location.latitude}, ${'$'}{location.longitude}")
         val request = PutDataMapRequest.create("/location").apply {

--- a/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
@@ -149,6 +149,7 @@ class MainActivity : AppCompatActivity() {
         runOnUiThread {
             cityName = text
             findViewById<TextView>(R.id.city_text).text = text
+            locationSender.sendCityName(text)
         }
     }
 

--- a/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/MainActivity.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.noxob.namazvakti.SettingsSender
 
 class MainActivity : AppCompatActivity() {
 
@@ -66,6 +67,7 @@ class MainActivity : AppCompatActivity() {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         val lang = prefs.getString("language", "tr")!!
         AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(lang))
+        SettingsSender(this).send()
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->

--- a/mobile/src/main/java/com/noxob/namazvakti/SettingsActivity.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/SettingsActivity.kt
@@ -6,6 +6,8 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.preference.PreferenceFragmentCompat
 import android.content.SharedPreferences
+import com.noxob.namazvakti.SettingsSender
+
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,6 +39,9 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             val lang = sharedPreferences?.getString("language", "tr") ?: "tr"
             AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(lang))
             activity?.recreate()
+        }
+        if (key == "language" || key == "calc_method" || key == "madhab") {
+            SettingsSender(requireContext()).send()
         }
     }
 }

--- a/mobile/src/main/java/com/noxob/namazvakti/SettingsRequestService.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/SettingsRequestService.kt
@@ -1,0 +1,14 @@
+package com.noxob.namazvakti
+
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.WearableListenerService
+
+class SettingsRequestService : WearableListenerService() {
+    override fun onMessageReceived(messageEvent: MessageEvent) {
+        if (messageEvent.path == "/request_settings") {
+            SettingsSender(this).send()
+        } else {
+            super.onMessageReceived(messageEvent)
+        }
+    }
+}

--- a/mobile/src/main/java/com/noxob/namazvakti/SettingsSender.kt
+++ b/mobile/src/main/java/com/noxob/namazvakti/SettingsSender.kt
@@ -1,0 +1,32 @@
+package com.noxob.namazvakti
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import com.batoulapps.adhan2.CalculationMethod
+import com.batoulapps.adhan2.Madhab
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+
+class SettingsSender(private val context: Context) {
+    private val dataClient = Wearable.getDataClient(context)
+
+    fun send() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val method = prefs.getString(
+            "calc_method",
+            CalculationMethod.MUSLIM_WORLD_LEAGUE.name
+        )!!
+        val madhab = prefs.getString(
+            "madhab",
+            Madhab.SHAFI.name
+        )!!
+        val language = prefs.getString("language", "tr")!!
+        val request = PutDataMapRequest.create("/settings").apply {
+            dataMap.putString("calc_method", method)
+            dataMap.putString("madhab", madhab)
+            dataMap.putString("language", language)
+            dataMap.putLong("time", System.currentTimeMillis())
+        }.asPutDataRequest().setUrgent()
+        dataClient.putDataItem(request)
+    }
+}

--- a/wear/src/main/java/com/noxob/namazvakti/PrayerTimeCalculator.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/PrayerTimeCalculator.kt
@@ -189,29 +189,32 @@ object PrayerTimeCalculator {
         val cachedLat = prefs.getFloat(CACHE_LAT, 0f).toDouble()
         val cachedLng = prefs.getFloat(CACHE_LNG, 0f).toDouble()
 
-        if (cachedDay == today && isLocationClose(lat, lng, cachedLat, cachedLng)) {
+        val useCache = cachedDay == today && isLocationClose(lat, lng, cachedLat, cachedLng)
+        val cachedResult = if (useCache) {
             val todayStr = prefs.getString(CACHE_TODAY, null)
             val tomorrowStr = prefs.getString(CACHE_TOMORROW, null)
             if (todayStr != null && tomorrowStr != null) {
                 val todayTimes = parseTimes(todayStr)
                 val tomorrowTimes = parseTimes(tomorrowStr)
                 val yesterdayTimes = computeTimes(lat, lng, yesterday, prefs)
-                return@withContext Triple(yesterdayTimes, todayTimes, tomorrowTimes)
-            }
-        }
+                Triple(yesterdayTimes, todayTimes, tomorrowTimes)
+            } else null
+        } else null
 
-        val tomorrow = today.plusDays(1)
-        val yesterdayTimes = computeTimes(lat, lng, yesterday, prefs)
-        val todayTimes = computeTimes(lat, lng, today, prefs)
-        val tomorrowTimes = computeTimes(lat, lng, tomorrow, prefs)
-        prefs.edit()
-            .putString(CACHE_DAY, today.toString())
-            .putFloat(CACHE_LAT, lat.toFloat())
-            .putFloat(CACHE_LNG, lng.toFloat())
-            .putString(CACHE_TODAY, formatTimes(todayTimes))
-            .putString(CACHE_TOMORROW, formatTimes(tomorrowTimes))
-            .apply()
-        Triple(yesterdayTimes, todayTimes, tomorrowTimes)
+        cachedResult ?: run {
+            val tomorrow = today.plusDays(1)
+            val yesterdayTimes = computeTimes(lat, lng, yesterday, prefs)
+            val todayTimes = computeTimes(lat, lng, today, prefs)
+            val tomorrowTimes = computeTimes(lat, lng, tomorrow, prefs)
+            prefs.edit()
+                .putString(CACHE_DAY, today.toString())
+                .putFloat(CACHE_LAT, lat.toFloat())
+                .putFloat(CACHE_LNG, lng.toFloat())
+                .putString(CACHE_TODAY, formatTimes(todayTimes))
+                .putString(CACHE_TOMORROW, formatTimes(tomorrowTimes))
+                .apply()
+            Triple(yesterdayTimes, todayTimes, tomorrowTimes)
+        }
     }
 
     fun prayerWindow(

--- a/wear/src/main/java/com/noxob/namazvakti/PrayerTimeCalculator.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/PrayerTimeCalculator.kt
@@ -1,0 +1,216 @@
+package com.noxob.namazvakti
+
+import android.Manifest
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.tasks.await
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.util.TimeZone
+import com.batoulapps.adhan2.CalculationMethod
+import com.batoulapps.adhan2.Coordinates
+import com.batoulapps.adhan2.Madhab
+import com.batoulapps.adhan2.PrayerTimes
+import com.batoulapps.adhan2.data.DateComponents
+import kotlinx.datetime.toJavaInstant
+import kotlin.math.*
+
+object PrayerTimeCalculator {
+    private const val TAG = "PrayerCalc"
+    private const val PREFS = "prayer_cache"
+    private const val LAST_LAT = "last_lat"
+    private const val LAST_LNG = "last_lng"
+    private const val CACHE_DAY = "cache_day"
+    private const val CACHE_LAT = "cache_lat"
+    private const val CACHE_LNG = "cache_lng"
+    private const val CACHE_TODAY = "cache_today"
+    private const val CACHE_TOMORROW = "cache_tomorrow"
+
+    suspend fun getLocation(context: Context): Pair<Double, Double> = withContext(Dispatchers.IO) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val dataClient = Wearable.getDataClient(context)
+        val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+
+        val watchLocation = if (
+            context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            try {
+                withTimeoutOrNull(2000) { fusedClient.lastLocation.await() }
+            } catch (e: Exception) {
+                Log.w(TAG, "Watch location unavailable", e)
+                null
+            }
+        } else null
+
+        val locFromWatch = watchLocation?.let { it.latitude to it.longitude }
+
+        val locFromPhone = locFromWatch ?: run {
+            val uri = Uri.parse("wear://*/location")
+            val buffer = try {
+                withTimeoutOrNull(2000) { dataClient.getDataItems(uri).await() }
+            } catch (e: CancellationException) {
+                Log.w(TAG, "Location task cancelled", e)
+                null
+            } catch (e: Exception) {
+                Log.e(TAG, "Error reading location", e)
+                null
+            }
+
+            buffer?.use { buf ->
+                if (buf.count > 0) {
+                    val map = DataMapItem.fromDataItem(buf[0]).dataMap
+                    map.getDouble("lat") to map.getDouble("lng")
+                } else null
+            }
+        }
+
+        val finalLoc = locFromPhone ?: loadLastLocation(prefs) ?: run {
+            Log.w(TAG, "No location found; using fallback")
+            39.91987 to 32.85427
+        }
+
+        saveLastLocation(prefs, finalLoc.first, finalLoc.second)
+        finalLoc
+    }
+
+    suspend fun fetchPrayerTimes(
+        context: Context,
+        lat: Double,
+        lng: Double
+    ): Triple<List<LocalTime>, List<LocalTime>, List<LocalTime>> = withContext(Dispatchers.Default) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val today = LocalDate.now()
+        val yesterday = today.minusDays(1)
+
+        val cachedDay = prefs.getString(CACHE_DAY, null)?.let { LocalDate.parse(it) }
+        val cachedLat = prefs.getFloat(CACHE_LAT, 0f).toDouble()
+        val cachedLng = prefs.getFloat(CACHE_LNG, 0f).toDouble()
+
+        if (cachedDay == today && isLocationClose(lat, lng, cachedLat, cachedLng)) {
+            val todayStr = prefs.getString(CACHE_TODAY, null)
+            val tomorrowStr = prefs.getString(CACHE_TOMORROW, null)
+            if (todayStr != null && tomorrowStr != null) {
+                val todayTimes = parseTimes(todayStr)
+                val tomorrowTimes = parseTimes(tomorrowStr)
+                val yesterdayTimes = computeTimes(lat, lng, yesterday)
+                return@withContext Triple(yesterdayTimes, todayTimes, tomorrowTimes)
+            }
+        }
+
+        val tomorrow = today.plusDays(1)
+        val yesterdayTimes = computeTimes(lat, lng, yesterday)
+        val todayTimes = computeTimes(lat, lng, today)
+        val tomorrowTimes = computeTimes(lat, lng, tomorrow)
+        prefs.edit()
+            .putString(CACHE_DAY, today.toString())
+            .putFloat(CACHE_LAT, lat.toFloat())
+            .putFloat(CACHE_LNG, lng.toFloat())
+            .putString(CACHE_TODAY, formatTimes(todayTimes))
+            .putString(CACHE_TOMORROW, formatTimes(tomorrowTimes))
+            .apply()
+        Triple(yesterdayTimes, todayTimes, tomorrowTimes)
+    }
+
+    fun prayerWindow(
+        now: LocalDateTime,
+        yesterday: List<LocalTime>,
+        today: List<LocalTime>,
+        tomorrow: List<LocalTime>
+    ): Triple<String, LocalDateTime, LocalDateTime> {
+        val names = listOf("Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha")
+        for (i in today.indices) {
+            val end = LocalDateTime.of(now.toLocalDate(), today[i])
+            if (end.isAfter(now)) {
+                val start = if (i == 0) {
+                    LocalDateTime.of(now.toLocalDate().minusDays(1), yesterday.last())
+                } else {
+                    LocalDateTime.of(now.toLocalDate(), today[i - 1])
+                }
+                return Triple(names[i], start, end)
+            }
+        }
+        val start = LocalDateTime.of(now.toLocalDate(), today.last())
+        val end = LocalDateTime.of(now.toLocalDate().plusDays(1), tomorrow[0])
+        return Triple(names[0], start, end)
+    }
+
+    fun kerahatInterval(
+        now: LocalDateTime,
+        today: List<LocalTime>
+    ): Pair<LocalDateTime, LocalDateTime>? {
+        val sunrise = LocalDateTime.of(now.toLocalDate(), today[1])
+        val dhuhr = LocalDateTime.of(now.toLocalDate(), today[2])
+        val maghrib = LocalDateTime.of(now.toLocalDate(), today[4])
+
+        val sunriseEnd = sunrise.plusMinutes(45)
+        val dhuhrStart = dhuhr.minusMinutes(45)
+        val maghribStart = maghrib.minusMinutes(45)
+
+        return when {
+            !now.isBefore(sunrise) && now.isBefore(sunriseEnd) -> sunrise to sunriseEnd
+            !now.isBefore(dhuhrStart) && now.isBefore(dhuhr) -> dhuhrStart to dhuhr
+            !now.isBefore(maghribStart) && now.isBefore(maghrib) -> maghribStart to maghrib
+            else -> null
+        }
+    }
+
+    private fun formatTimes(times: List<LocalTime>) =
+        times.joinToString(",") { it.toString() }
+
+    private fun parseTimes(str: String): List<LocalTime> =
+        str.split(',').map { LocalTime.parse(it) }
+
+    private fun isLocationClose(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Boolean {
+        val R = 6371000.0
+        val phi1 = Math.toRadians(lat1)
+        val phi2 = Math.toRadians(lat2)
+        val dPhi = Math.toRadians(lat2 - lat1)
+        val dLambda = Math.toRadians(lon2 - lon1)
+        val a = sin(dPhi / 2).pow(2.0) + cos(phi1) * cos(phi2) * sin(dLambda / 2).pow(2.0)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        val distance = R * c
+        return distance < 20_000
+    }
+
+    private fun computeTimes(lat: Double, lng: Double, date: LocalDate): List<LocalTime> {
+        val coordinates = Coordinates(lat, lng)
+        val params = CalculationMethod.TURKEY.parameters.copy(madhab = Madhab.SHAFI)
+        val components = DateComponents(date.year, date.monthValue, date.dayOfMonth)
+        val times = PrayerTimes(coordinates, components, params)
+        val offsetMinutes = TimeZone.getDefault().rawOffset / 60000
+        val zoneOffset = ZoneOffset.ofTotalSeconds(offsetMinutes * 60)
+        return listOf(
+            times.fajr,
+            times.sunrise,
+            times.dhuhr,
+            times.asr,
+            times.maghrib,
+            times.isha
+        ).map { instant ->
+            instant.toJavaInstant().atOffset(zoneOffset).toLocalTime()
+        }
+    }
+
+    private fun saveLastLocation(prefs: SharedPreferences, lat: Double, lng: Double) {
+        prefs.edit().putFloat(LAST_LAT, lat.toFloat()).putFloat(LAST_LNG, lng.toFloat()).apply()
+    }
+
+    private fun loadLastLocation(prefs: SharedPreferences): Pair<Double, Double>? {
+        if (!prefs.contains(LAST_LAT) || !prefs.contains(LAST_LNG)) return null
+        return prefs.getFloat(LAST_LAT, 0f).toDouble() to prefs.getFloat(LAST_LNG, 0f).toDouble()
+    }
+}
+

--- a/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
@@ -158,12 +158,12 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
         val totalMinutes = duration.toMinutes().coerceAtLeast(0)
         val hours = totalMinutes / 60
         val minutes = totalMinutes % 60
-        val textStr = if (hours > 0) "${'$'}{hours}s ${'$'}{minutes}d" else "${'$'}{minutes}d"
+        val textStr = if (hours > 0) "${hours}s ${minutes}d" else "${minutes}d"
         val text = PlainComplicationText.Builder(textStr).build()
         val descStr = if (isKerahat) {
-            if (lang == "tr") "Kerahat ${'$'}displayName'e kadar" else "Kerahat until ${'$'}displayName"
+            if (lang == "tr") "Kerahat ${displayName}'e kadar" else "Kerahat until $displayName"
         } else {
-            if (lang == "tr") "${'$'}displayName'e kadar" else "Time until ${'$'}displayName"
+            if (lang == "tr") "$displayName'e kadar" else "Time until $displayName"
         }
         val description = PlainComplicationText.Builder(descStr).build()
 

--- a/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
@@ -51,6 +51,7 @@ import com.batoulapps.adhan2.data.DateComponents
 import kotlinx.datetime.toJavaInstant
 import kotlin.math.*
 import com.noxob.namazvakti.PrayerTimeCalculator
+import com.noxob.namazvakti.tile.MainTileService
 
 class MainComplicationService : SuspendingComplicationDataSourceService() {
 
@@ -93,6 +94,7 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
     }
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData {
+        MainTileService.refreshIfStale(this)
         return try {
             Log.d(TAG, "Complication requested: $request")
             val (lat, lng) = PrayerTimeCalculator.getLocation(this)

--- a/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
@@ -128,6 +128,7 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
         } catch (e: Exception) {
             Log.e(TAG, "Error creating complication", e)
             val now = LocalDateTime.now()
+            scheduleComplicationUpdate(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1))
             createComplicationData(
                 request.complicationType,
                 "Prayer",
@@ -340,11 +341,11 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
 
     private fun scheduleComplicationUpdate(triggerAtMillis: Long) {
         val delay = max(0L, triggerAtMillis - System.currentTimeMillis())
-        val requester = ComplicationDataSourceUpdateRequester.create(
-            this,
-            ComponentName(this, MainComplicationService::class.java)
-        )
         Handler(Looper.getMainLooper()).postDelayed({
+            val requester = ComplicationDataSourceUpdateRequester.create(
+                applicationContext,
+                ComponentName(applicationContext, MainComplicationService::class.java)
+            )
             requester.requestUpdateAll()
         }, delay)
     }

--- a/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
@@ -1,18 +1,11 @@
 package com.noxob.namazvakti.complication
 
-import android.Manifest
 import android.content.ComponentName
-import android.content.SharedPreferences
-import android.content.pm.PackageManager
 import android.graphics.drawable.Icon
 import android.graphics.Color
-import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import com.google.android.gms.location.LocationServices
-import com.google.android.gms.wearable.DataMapItem
-import com.google.android.gms.wearable.Wearable
 import androidx.wear.watchface.complications.data.ComplicationData
 import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.data.MonochromaticImage
@@ -30,46 +23,19 @@ import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.tasks.await
-import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.ZoneId
-import java.time.ZoneOffset
 import java.time.Duration
 import java.time.Instant
-import java.util.TimeZone
 import java.util.concurrent.TimeUnit
-import com.batoulapps.adhan2.CalculationMethod
-import com.batoulapps.adhan2.Coordinates
-import com.batoulapps.adhan2.PrayerTimes
-import com.batoulapps.adhan2.Madhab
-import com.batoulapps.adhan2.data.DateComponents
-import kotlinx.datetime.toJavaInstant
-import kotlin.math.*
+import kotlin.math.max
 import com.noxob.namazvakti.PrayerTimeCalculator
 import com.noxob.namazvakti.tile.MainTileService
 
 class MainComplicationService : SuspendingComplicationDataSourceService() {
 
-    private val dataClient by lazy { Wearable.getDataClient(this) }
-    private val fusedClient by lazy { LocationServices.getFusedLocationProviderClient(this) }
-    private val prefs: SharedPreferences by lazy {
-        getSharedPreferences("prayer_cache", MODE_PRIVATE)
-    }
-
     companion object {
         private const val TAG = "MainComplication"
-        private const val LAST_LAT = "last_lat"
-        private const val LAST_LNG = "last_lng"
-        private const val CACHE_DAY = "cache_day"
-        private const val CACHE_LAT = "cache_lat"
-        private const val CACHE_LNG = "cache_lng"
-        private const val CACHE_TODAY = "cache_today"
-        private const val CACHE_TOMORROW = "cache_tomorrow"
     }
 
     override fun getPreviewData(type: ComplicationType): ComplicationData? {
@@ -222,123 +188,6 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
         }
         return Icon.createWithResource(this, res)
     }
-
-    private fun prayerWindow(
-        now: LocalDateTime,
-        yesterday: List<LocalTime>,
-        today: List<LocalTime>,
-        tomorrow: List<LocalTime>
-    ): Triple<String, LocalDateTime, LocalDateTime> {
-        val names = listOf("Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha")
-        for (i in today.indices) {
-            val end = LocalDateTime.of(now.toLocalDate(), today[i])
-            if (end.isAfter(now)) {
-                val start = if (i == 0) {
-                    LocalDateTime.of(now.toLocalDate().minusDays(1), yesterday.last())
-                } else {
-                    LocalDateTime.of(now.toLocalDate(), today[i - 1])
-                }
-                return Triple(names[i], start, end)
-            }
-        }
-        val start = LocalDateTime.of(now.toLocalDate(), today.last())
-        val end = LocalDateTime.of(now.toLocalDate().plusDays(1), tomorrow[0])
-        return Triple(names[0], start, end)
-    }
-
-    private fun kerahatInterval(
-        now: LocalDateTime,
-        today: List<LocalTime>
-    ): Pair<LocalDateTime, LocalDateTime>? {
-        val sunrise = LocalDateTime.of(now.toLocalDate(), today[1])
-        val dhuhr = LocalDateTime.of(now.toLocalDate(), today[2])
-        val maghrib = LocalDateTime.of(now.toLocalDate(), today[4])
-
-        val sunriseEnd = sunrise.plusMinutes(45)
-        val dhuhrStart = dhuhr.minusMinutes(45)
-        val maghribStart = maghrib.minusMinutes(45)
-
-        return when {
-            !now.isBefore(sunrise) && now.isBefore(sunriseEnd) -> sunrise to sunriseEnd
-            !now.isBefore(dhuhrStart) && now.isBefore(dhuhr) -> dhuhrStart to dhuhr
-            !now.isBefore(maghribStart) && now.isBefore(maghrib) -> maghribStart to maghrib
-            else -> null
-        }
-    }
-
-    private suspend fun fetchPrayerTimes(
-        lat: Double,
-        lng: Double
-    ): Triple<List<LocalTime>, List<LocalTime>, List<LocalTime>> = withContext(Dispatchers.Default) {
-        val today = LocalDate.now()
-        val yesterday = today.minusDays(1)
-
-        val cachedDay = prefs.getString(CACHE_DAY, null)?.let { LocalDate.parse(it) }
-        val cachedLat = prefs.getFloat(CACHE_LAT, 0f).toDouble()
-        val cachedLng = prefs.getFloat(CACHE_LNG, 0f).toDouble()
-
-        if (cachedDay == today && isLocationClose(lat, lng, cachedLat, cachedLng)) {
-            val todayStr = prefs.getString(CACHE_TODAY, null)
-            val tomorrowStr = prefs.getString(CACHE_TOMORROW, null)
-            if (todayStr != null && tomorrowStr != null) {
-                val todayTimes = parseTimes(todayStr)
-                val tomorrowTimes = parseTimes(tomorrowStr)
-                val yesterdayTimes = computeTimes(lat, lng, yesterday)
-                return@withContext Triple(yesterdayTimes, todayTimes, tomorrowTimes)
-            }
-        }
-
-        val tomorrow = today.plusDays(1)
-        val yesterdayTimes = computeTimes(lat, lng, yesterday)
-        val todayTimes = computeTimes(lat, lng, today)
-        val tomorrowTimes = computeTimes(lat, lng, tomorrow)
-        prefs.edit()
-            .putString(CACHE_DAY, today.toString())
-            .putFloat(CACHE_LAT, lat.toFloat())
-            .putFloat(CACHE_LNG, lng.toFloat())
-            .putString(CACHE_TODAY, formatTimes(todayTimes))
-            .putString(CACHE_TOMORROW, formatTimes(tomorrowTimes))
-            .apply()
-        Triple(yesterdayTimes, todayTimes, tomorrowTimes)
-    }
-
-    private fun formatTimes(times: List<LocalTime>) =
-        times.joinToString(",") { it.toString() }
-
-    private fun parseTimes(str: String): List<LocalTime> =
-        str.split(',').map { LocalTime.parse(it) }
-
-    private fun isLocationClose(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Boolean {
-        val R = 6371000.0
-        val phi1 = Math.toRadians(lat1)
-        val phi2 = Math.toRadians(lat2)
-        val dPhi = Math.toRadians(lat2 - lat1)
-        val dLambda = Math.toRadians(lon2 - lon1)
-        val a = sin(dPhi / 2).pow(2.0) + cos(phi1) * cos(phi2) * sin(dLambda / 2).pow(2.0)
-        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
-        val distance = R * c
-        return distance < 20_000 // within ~20km ≈ 1 minute difference
-    }
-
-    private fun computeTimes(lat: Double, lng: Double, date: LocalDate): List<LocalTime> {
-        val coordinates = Coordinates(lat, lng)
-        val params = CalculationMethod.TURKEY.parameters.copy(madhab = Madhab.SHAFI)
-        val components = DateComponents(date.year, date.monthValue, date.dayOfMonth)
-        val times = PrayerTimes(coordinates, components, params)
-        val offsetMinutes = TimeZone.getDefault().rawOffset / 60000
-        val zoneOffset = ZoneOffset.ofTotalSeconds(offsetMinutes * 60)
-        return listOf(
-            times.fajr,
-            times.sunrise,
-            times.dhuhr,
-            times.asr,
-            times.maghrib,
-            times.isha
-        ).map { instant ->
-            instant.toJavaInstant().atOffset(zoneOffset).toLocalTime()
-        }
-    }
-
     private fun scheduleComplicationUpdate(triggerAtMillis: Long) {
         val delay = max(0L, triggerAtMillis - System.currentTimeMillis())
         Handler(Looper.getMainLooper()).postDelayed({
@@ -348,58 +197,5 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
             )
             requester.requestUpdateAll()
         }, delay)
-    }
-
-    private suspend fun getLocation(): Pair<Double, Double> = withContext(Dispatchers.IO) {
-        val watchLocation = if (
-            checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
-                PackageManager.PERMISSION_GRANTED
-        ) {
-            try {
-                withTimeoutOrNull(2000) { fusedClient.lastLocation.await() }
-            } catch (e: Exception) {
-                Log.w(TAG, "Watch location unavailable", e)
-                null
-            }
-        } else null
-
-        val locFromWatch = watchLocation?.let { it.latitude to it.longitude }
-
-        val locFromPhone = locFromWatch ?: run {
-            val uri = Uri.parse("wear://*/location")
-            val buffer = try {
-                withTimeoutOrNull(2000) { dataClient.getDataItems(uri).await() }
-            } catch (e: CancellationException) {
-                Log.w(TAG, "Location task cancelled", e)
-                null
-            } catch (e: Exception) {
-                Log.e(TAG, "Error reading location", e)
-                null
-            }
-
-            buffer?.use { buf ->
-                if (buf.count > 0) {
-                    val map = DataMapItem.fromDataItem(buf[0]).dataMap
-                    map.getDouble("lat") to map.getDouble("lng")
-                } else null
-            }
-        }
-
-        val finalLoc = locFromPhone ?: loadLastLocation() ?: run {
-            Log.w(TAG, "No location found; using fallback")
-            39.91987 to 32.85427
-        }
-
-        saveLastLocation(finalLoc.first, finalLoc.second)
-        finalLoc
-    }
-
-    private fun saveLastLocation(lat: Double, lng: Double) {
-        prefs.edit().putFloat(LAST_LAT, lat.toFloat()).putFloat(LAST_LNG, lng.toFloat()).apply()
-    }
-
-    private fun loadLastLocation(): Pair<Double, Double>? {
-        if (!prefs.contains(LAST_LAT) || !prefs.contains(LAST_LNG)) return null
-        return prefs.getFloat(LAST_LAT, 0f).toDouble() to prefs.getFloat(LAST_LNG, 0f).toDouble()
     }
 }

--- a/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/complication/MainComplicationService.kt
@@ -50,6 +50,7 @@ import com.batoulapps.adhan2.Madhab
 import com.batoulapps.adhan2.data.DateComponents
 import kotlinx.datetime.toJavaInstant
 import kotlin.math.*
+import com.noxob.namazvakti.PrayerTimeCalculator
 
 class MainComplicationService : SuspendingComplicationDataSourceService() {
 
@@ -93,15 +94,15 @@ class MainComplicationService : SuspendingComplicationDataSourceService() {
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData {
         return try {
             Log.d(TAG, "Complication requested: $request")
-            val (lat, lng) = getLocation()
+            val (lat, lng) = PrayerTimeCalculator.getLocation(this)
             Log.d(TAG, "Using location $lat,$lng")
-            val (yesterday, today, tomorrow) = fetchPrayerTimes(lat, lng)
+            val (yesterday, today, tomorrow) = PrayerTimeCalculator.fetchPrayerTimes(this, lat, lng)
             Log.d(TAG, "Fetched prayer times")
             val now = LocalDateTime.now()
-            val (name, start, end) = prayerWindow(now, yesterday, today, tomorrow)
+            val (name, start, end) = PrayerTimeCalculator.prayerWindow(now, yesterday, today, tomorrow)
             Log.d(TAG, "Next prayer $name at $end")
 
-            val kerahat = kerahatInterval(now, today)
+            val kerahat = PrayerTimeCalculator.kerahatInterval(now, today)
             val isKerahat = kerahat != null
             val (kStart, kEnd) = kerahat ?: (start to end)
 

--- a/wear/src/main/java/com/noxob/namazvakti/presentation/MainActivity.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/presentation/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
 import com.noxob.namazvakti.R
 import com.noxob.namazvakti.complication.MainComplicationService
+import com.noxob.namazvakti.tile.MainTileService
 import com.noxob.namazvakti.presentation.theme.NamazVaktiTheme
 
 class MainActivity : ComponentActivity() {
@@ -52,6 +53,8 @@ class MainActivity : ComponentActivity() {
         ).requestUpdateAll().also {
             Log.d("MainActivity", "Requested complication update")
         }
+
+        MainTileService.refreshIfStale(this)
 
         setContent {
             WearApp("Android")

--- a/wear/src/main/java/com/noxob/namazvakti/tile/MainTileService.kt
+++ b/wear/src/main/java/com/noxob/namazvakti/tile/MainTileService.kt
@@ -56,19 +56,28 @@ private suspend fun tile(
     val city = PrayerTimeCalculator.getCityName(context, lat, lng)
     val (yesterday, today, tomorrow) = PrayerTimeCalculator.fetchPrayerTimes(context, lat, lng)
     val now = LocalDateTime.now()
+    val lang = PrayerTimeCalculator.getLanguage(context)
     val (nextName, _, nextEnd) = PrayerTimeCalculator.prayerWindow(now, yesterday, today, tomorrow)
+    val displayNextName = PrayerTimeCalculator.translatePrayerName(nextName, lang)
     val countdown = Duration.between(now, nextEnd)
-    val names = listOf("Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha")
-    val kerahat = if (PrayerTimeCalculator.kerahatInterval(now, today) != null) "Kerahat" else "Normal"
+    val rawNames = listOf("Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha")
+    val times = rawNames.zip(today).map { (n, t) ->
+        PrayerTimeCalculator.translatePrayerName(n, lang) to t
+    }
+    val kerahat = if (PrayerTimeCalculator.kerahatInterval(now, today) != null) {
+        if (lang == "tr") "Kerahat" else "Kerahat"
+    } else {
+        if (lang == "tr") "Normal" else "Normal"
+    }
 
     val layout = tileLayout(
         requestParams,
         context,
         city,
-        nextName,
+        displayNextName,
         nextEnd.toLocalTime(),
         countdown,
-        names.zip(today),
+        times,
         kerahat
     )
 


### PR DESCRIPTION
## Summary
- share prayer time calculations via `PrayerTimeCalculator`
- use shared data in `MainTileService` so the tile shows real prayer times
- hook complication service into the shared calculator

## Testing
- `./gradlew :wear:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc190526883339104aca5eb688167